### PR TITLE
Added repel option to geom_node_text

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     scales,
     MASS,
     digest,
-    gtable
+    gtable,
+    ggrepel
 LinkingTo: Rcpp
 RoxygenNote: 5.0.1
 Depends: ggplot2 (>= 2.0.0)

--- a/R/geom_node_text.R
+++ b/R/geom_node_text.R
@@ -42,7 +42,11 @@
 #' Useful for offsetting text from points, particularly on discrete scales.
 #'
 #' @param check_overlap If \code{TRUE}, text that overlaps previous text in the
-#' same layer will not be plotted. A quick and dirty way
+#' same layer will not be plotted. Ignored if repel = TRUE. A quick and dirty way.
+#' 
+#' @param repel If \code{TRUE}, text labels will be repelled from each other
+#' to avoid overlapping, using the \code{GeomTextRepel} geom from the
+#' ggrepel package.
 #'
 #' @param ... other arguments passed on to \code{\link[ggplot2]{layer}}. There
 #' are three types of arguments you can use here:
@@ -74,11 +78,19 @@
 #'
 geom_node_text <- function(mapping = NULL, data = NULL, position = "identity",
                            parse = FALSE, nudge_x = 0, nudge_y = 0,
-                           check_overlap = FALSE, show.legend = NA, ...) {
+                           check_overlap = FALSE, show.legend = NA,
+                           repel = FALSE, ...) {
+    params <- list(parse = parse, na.rm = FALSE, ...)
+    if (repel) {
+      geom <- ggrepel::GeomTextRepel
+    } else {
+      geom <- GeomText
+      params$check_overlap <- check_overlap
+    }
+  
     mapping <- aesIntersect(mapping, aes_(x=~x, y=~y))
-    layer(data = data, mapping = mapping, stat = StatFilter, geom = GeomText,
+    layer(data = data, mapping = mapping, stat = StatFilter, geom = geom,
           position = position, show.legend = show.legend, inherit.aes = FALSE,
-          params = list(parse = parse, check_overlap = check_overlap,
-                        na.rm = FALSE, ...)
+          params = params
     )
 }

--- a/man/geom_node_text.Rd
+++ b/man/geom_node_text.Rd
@@ -6,7 +6,7 @@
 \usage{
 geom_node_text(mapping = NULL, data = NULL, position = "identity",
   parse = FALSE, nudge_x = 0, nudge_y = 0, check_overlap = FALSE,
-  show.legend = NA, ...)
+  show.legend = NA, repel = FALSE, ...)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2]{aes}}
@@ -33,6 +33,10 @@ same layer will not be plotted. A quick and dirty way}
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped. \code{FALSE}
 never includes, and \code{TRUE} always includes.}
+
+\item{repel}{If \code{TRUE}, text labels will be repelled from each other
+to avoid overlapping, using the \code{GeomTextRepel} geom from the
+ggrepel package.}
 
 \item{...}{other arguments passed on to \code{\link[ggplot2]{layer}}. There
 are three types of arguments you can use here:


### PR DESCRIPTION
This would enable the use of ggrepel to create text labels that point to each node. (Default FALSE)

As one example, of relationships between Stack Exchange network sites:

![image](https://cloud.githubusercontent.com/assets/994718/13584481/d07f35e8-e484-11e5-968e-4e8350c44d3e.png)
