### PR TITLE
udpate viridis palette with named args

### DIFF
--- a/R/scale_edge_colour.R
+++ b/R/scale_edge_colour.R
@@ -130,10 +130,12 @@ scale_edge_colour_viridis <- function (..., alpha = 1, begin = 0, end = 1,
     }
     if (discrete) {
         discrete_scale("edge_colour", "viridis",
-                       viridis_pal(alpha, begin, end, option), ...)
+                       viridis_pal(alpha = alpha, begin = begin, end = end,
+                                   option = option), ...)
     } else {
-        scale_edge_colour_gradientn(colours = viridis(256, alpha, begin,
-                                                      end, option), ...)
+        scale_edge_colour_gradientn(colours = viridis(256, alpha = alpha,
+                                                    begin = begin, end = end,
+                                                    option = option), ...)
     }
 }
 #' @rdname scale_edge_colour

--- a/R/scale_edge_fill.R
+++ b/R/scale_edge_fill.R
@@ -130,10 +130,12 @@ scale_edge_fill_viridis <- function (..., alpha = 1, begin = 0, end = 1,
     }
     if (discrete) {
         discrete_scale("edge_fill", "viridis",
-                       viridis_pal(alpha, begin, end, option), ...)
+                       viridis_pal(alpha = alpha, begin = begin, end = end,
+                                   option = option), ...)
     } else {
-        scale_edge_fill_gradientn(colours = viridis(256, alpha, begin,
-                                                     end, option), ...)
+        scale_edge_fill_gradientn(colours = viridis(256, alpha = alpha,
+                                                    begin = begin, end = end,
+                                                    option = option), ...)
     }
 }
 #' @rdname scale_edge_fill


### PR DESCRIPTION
The package viridis added a direction argument between the end and option args. This caused the current version of viridis to interpret "D" as a direction by default, causing an error.

This commit will preserve the default behavior and allow for backwards-compatibility with older versions of viridis.