### PR TITLE
Fix: ggraph fails to compile on macOS 10.10.5 with system clang++

### DIFF
--- a/src/circlePack.cpp
+++ b/src/circlePack.cpp
@@ -444,7 +444,7 @@ NumericMatrix pack(NumericVector areas) {
     std::deque<Circle> circles;
     NumericMatrix res(areas.size(), 2);
     for (itr = areas.begin(); itr != areas.end(); itr++) {
-        Circle c = {0, 0, std::sqrt(float(*itr / M_PI)), circles.size() + 1};
+        Circle c = {0, 0, std::sqrt(float(*itr / M_PI)), static_cast<int>(circles.size()) + 1};
         circles.push_back(c);
     }
     if (circles.size() == 0) {


### PR DESCRIPTION
I’m getting an error in [`circlePack.cpp` L445](https://github.com/thomasp85/ggraph/blob/9d5061116bda45c72f5f9bb569be4bd613df8803/src/circlePack.cpp#L447):

> error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'int' in initializer list [-Wc++11-narrowing]

As far as I can see the error message is correct, and this PR fixes it by making the conversion explicit.

<details>
<summary>Full error message</summary>

```
clang++ -stdlib=libc++ -I/usr/local/Cellar/r/3.4.1_1/R.framework/Resources/include -DNDEBUG  -I"/Users/rudolph/.R/packages/Rcpp/include" -I/usr/local/opt/gettext/include -I/usr/local/opt/readline/include -I/usr/local/include   -fPIC  -g -O2  -isystem /usr/local/opt/llvm/include -std=c++1y -c RcppExports.cpp -o RcppExports.o
clang++ -stdlib=libc++ -I/usr/local/Cellar/r/3.4.1_1/R.framework/Resources/include -DNDEBUG  -I"/Users/rudolph/.R/packages/Rcpp/include" -I/usr/local/opt/gettext/include -I/usr/local/opt/readline/include -I/usr/local/include   -fPIC  -g -O2  -isystem /usr/local/opt/llvm/include -std=c++1y -c circlePack.cpp -o circlePack.o
circlePack.cpp:447:58: error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'int' in initializer list [-Wc++11-narrowing]
        Circle c = {0, 0, std::sqrt(float(*itr / M_PI)), circles.size() + 1};
                                                         ^~~~~~~~~~~~~~~~~~
circlePack.cpp:447:58: note: insert an explicit cast to silence this issue
        Circle c = {0, 0, std::sqrt(float(*itr / M_PI)), circles.size() + 1};
                                                         ^~~~~~~~~~~~~~~~~~
                                                         static_cast<int>( )
1 error generated.
```

</details>