### PR TITLE
Fix documentation typos

### DIFF
--- a/R/cappedPath.R
+++ b/R/cappedPath.R
@@ -73,7 +73,7 @@ cappedPathGrob <- function(x, y, id=NULL, id.lengths=NULL, arrow = NULL,
 }
 #' Dynamic capping of paths
 #'
-#' This function takes care of updating which parts of the paths gets removed
+#' This function takes care of updating which parts of the paths get removed
 #' when the device dimensions are updated.
 #'
 #' @importFrom grid convertX convertY convertWidth convertHeight unit grob makeContent setChildren gList

--- a/R/connections.R
+++ b/R/connections.R
@@ -1,14 +1,14 @@
 #' Create a connection extractor function
 #'
 #' Connections within the ggraph terminology are links between nodes that are
-#' not part of the network structure itself. In that sense connections does not
+#' not part of the network structure itself. In that sense connections do not
 #' affect the layout calculation in any way and will not be drawn by the
 #' standard `geom_edge_*` functions. A connection does not need to only be
 #' defined by a start and end node, but can include intermediary nodes.
 #' `get_con` helps in creating connection data by letting you specify start
-#' and end node and automatically find the shortest path within the graph
+#' and end nodes and automatically finds the shortest path within the graph
 #' structure that connects the given points. If this is not what is needed it is
-#' also possible to supply a list of vectors giving node indexes that defines a
+#' also possible to supply a list of vectors giving node indices that define a
 #' connection.
 #'
 #' @param from,to The index of the start and end nodes for the connections

--- a/R/data_flare.R
+++ b/R/data_flare.R
@@ -10,7 +10,7 @@
 #' @format A list of three data.frames describing the software structure of
 #' flare:
 #' \describe{
-#'  \item{edges}{This data.frame maps the heirarchical structure of the class
+#'  \item{edges}{This data.frame maps the hierarchical structure of the class
 #'  hierarchy as an edgelist, with the class in `from` being the superclass
 #'  of the class in `to`.}
 #'  \item{vertices}{This data.frame gives additional information on the classes.

--- a/R/data_highschool.R
+++ b/R/data_highschool.R
@@ -14,7 +14,7 @@
 #' }
 #'
 #' @source
-#' Coleman, J. S. *Introduction to Mathermatical Sociology*. New York: Free
+#' Coleman, J. S. *Introduction to Mathematical Sociology*. New York: Free
 #' Press, pp.450-451.
 #'
 'highschool'

--- a/R/edges.R
+++ b/R/edges.R
@@ -23,7 +23,7 @@
 #'   \item{long}{In this format each edge consists of two rows with matching
 #'   `edge.id` value. The start and end position are both encoded in the
 #'   `x` and `y` column. The relative position of the rows determines
-#'   which is the start and end node, the first occuring being the start node.
+#'   which is the start and end node, the first occurring being the start node.
 #'   If node parameters are added to the edge data the name of the parameters
 #'   will be prefixed with `node.`.}
 #' }
@@ -37,7 +37,7 @@
 #' If the graph is not simple (it contains at most one edge between each node
 #' pair) it can be collapsed so either all edges between two nodes or all edges
 #' of the same direction between two nodes are merged. The edge parameters are
-#' taken from the first occuring edge, so if some more sophisticated summary is
+#' taken from the first occurring edge, so if some more sophisticated summary is
 #' needed it is suggested that the graph be tidied up before plotting with
 #' ggraph.
 #'

--- a/R/facet_graph.R
+++ b/R/facet_graph.R
@@ -4,7 +4,7 @@
 #' allows for building a grid of small multiples where rows and columns
 #' correspond to a specific data value. While [ggplot2::facet_grid()]
 #' could be used it would lead to unexpected results as it is not possible to
-#' specify whether you are refering to a node or an edge attribute. Furthermore
+#' specify whether you are referring to a node or an edge attribute. Furthermore
 #' [ggplot2::facet_grid()] will draw edges in panels even though the
 #' panel does not contain both terminal nodes. `facet_graph` takes care of
 #' all of these issues, allowing you to define which data type the rows and

--- a/R/geom_conn_bundle.R
+++ b/R/geom_conn_bundle.R
@@ -1,4 +1,4 @@
-#' Create heirarchical edge bundles between node connections
+#' Create hierarchical edge bundles between node connections
 #'
 #' Hierarchical edge bundling is a technique to introduce some order into the
 #' hairball structure that can appear when there's a lot of overplotting and
@@ -7,7 +7,7 @@
 #' Connections between points (that is, not edges) are then drawn so that they
 #' loosely follows the underlying hierarchical structure. This results in a
 #' flow-like structure where lines that partly move in the same direction will
-#' be bundled togeether.
+#' be bundled together.
 #'
 #' @note In order to avoid excessive typing edge aesthetic names are
 #' automatically expanded. Because of this it is not necessary to write

--- a/R/geom_edge_arc.R
+++ b/R/geom_edge_arc.R
@@ -2,7 +2,7 @@
 #'
 #' This geom is mainly intended for arc linear and circular diagrams (i.e. used
 #' together with [layout_tbl_graph_linear()]), though it can be used
-#' elsewere. It draws edges as arcs with a hight proportional to the distance
+#' elsewhere. It draws edges as arcs with a height proportional to the distance
 #' between the nodes. Arcs are calculated as beziers. For linear layout the
 #' placement of control points are related to the `curvature` argument and
 #' the distance between the two nodes. For circular layout the control points

--- a/R/geom_edge_diagonal.R
+++ b/R/geom_edge_diagonal.R
@@ -5,7 +5,7 @@
 #' A diagonal in this context is a quadratic bezier with the control points
 #' positioned halfway between the start and end points but on the same axis.
 #' This produces a pleasing fan-in, fan-out line that is mostly relevant for
-#' heirarchical layouts as it implies an overall directionality in the plot.
+#' hierarchical layouts as it implies an overall directionality in the plot.
 #'
 #' @inheritSection geom_edge_link Edge variants
 #' @inheritSection geom_edge_link Edge aesthetic name expansion

--- a/R/geom_edge_fan.R
+++ b/R/geom_edge_fan.R
@@ -5,7 +5,7 @@
 #' parallel edges. This results in parallel edges being drawn in a
 #' non-overlapping fashion resembling the standard approach used in
 #' [igraph::plot.igraph()]. Before calculating the curvature the edges
-#' are sorted by direction so that edges goind the same way will be adjacent.
+#' are sorted by direction so that edges going the same way will be adjacent.
 #' This geom is currently the only choice for non-simple graphs if edges should
 #' not be overplotted.
 #'

--- a/R/geom_edge_hive.R
+++ b/R/geom_edge_hive.R
@@ -2,7 +2,7 @@
 #'
 #' This geom is only intended for use together with the hive layout. It draws
 #' edges between nodes as bezier curves, with the control points positioned at
-#' the same radi as the start or end point, and at a distance defined by the
+#' the same radii as the start or end point, and at a distance defined by the
 #' curvature argument.
 #'
 #' @inheritSection geom_edge_link Edge variants

--- a/R/geom_edge_link.R
+++ b/R/geom_edge_link.R
@@ -19,7 +19,7 @@
 #'
 #' Often it is beneficial to stop the drawing of the edge before it reaches the
 #' node, for instance in cases where an arrow should be drawn and the arrowhead
-#' shouldn't lay ontop or below the node point. geom_edge_* and geom_edge_*2
+#' shouldn't lay on top or below the node point. geom_edge_* and geom_edge_*2
 #' supports this through the start_cap and end_cap aesthetics that takes a
 #' [geometry()] specification and dynamically caps the termini of the
 #' edges based on the given specifications. This means that if
@@ -100,7 +100,7 @@
 #' data.
 #'
 #' @param data The return of a call to `get_edges()` or a data.frame
-#' giving edges in corrent format (see details for for guidance on the format).
+#' giving edges in correct format (see details for for guidance on the format).
 #' See [get_edges()] for more details on edge extraction.
 #'
 #' @param n The number of points to create along the path.

--- a/R/geom_edge_point.R
+++ b/R/geom_edge_point.R
@@ -27,7 +27,7 @@
 #' data.
 #'
 #' @param data The return of a call to `get_edges()` or a data.frame
-#' giving edges in corrent format (see details for for guidance on the format).
+#' giving edges in correct format (see details for for guidance on the format).
 #' See [get_edges()] for more details on edge extraction.
 #'
 #' @param mirror Logical. Should edge points be duplicated on both sides of the

--- a/R/geom_node_circle.R
+++ b/R/geom_node_circle.R
@@ -2,7 +2,7 @@
 #'
 #' This geom is equivalent in functionality to [ggforce::geom_circle()]
 #' and allows for plotting of nodes as circles with a radius scaled by the
-#' coordinate system. Beceause of the geoms reliance on the coordinate system
+#' coordinate system. Because of the geoms reliance on the coordinate system
 #' it will only produce true circles when combined with
 #' [ggplot2::coord_fixed()]
 #'

--- a/R/geometry.R
+++ b/R/geometry.R
@@ -207,7 +207,7 @@ abs_width <- function(grobs) {
 }
 #' Define default scale type for geometry
 #'
-#' This functions is quite useless as geometry is not meant to be scaled, but it
+#' This function is quite useless as geometry is not meant to be scaled, but it
 #' is a requirement for ggplot2 to handle it correctly.
 #'
 #' @export

--- a/R/ggproto-classes.R
+++ b/R/ggproto-classes.R
@@ -12,7 +12,7 @@
 #' the functionality required. There will always be a base geom and some will
 #' have a `geom_edge_*0` and `geom_edge_*2` version. The base geom
 #' will, in the case of multiple versions, draw the edge as a sequence of small
-#' segments. The different aesthetics will be repeated for each seqgment and a
+#' segments. The different aesthetics will be repeated for each segment and a
 #' counter will be added the enumerates the progression of segments, so that a
 #' gradient of colour or size can be added along the edge by assigning the
 #' respective aesthetic to `..index..`. `geom_edge_*2` will also draw

--- a/R/ggraph.R
+++ b/R/ggraph.R
@@ -5,7 +5,7 @@
 #' for the plot based on the graph and the specification passed in.
 #' Alternatively a layout can be prepared in advance using
 #' `create_layout` and passed as the data argument. See *Details* for
-#' a desciption of all available layouts.
+#' a description of all available layouts.
 #'
 #' @details
 #' Following is a short description of the different layout types available in
@@ -49,7 +49,7 @@
 #'   within circles. Conceptually equal to treemaps. See
 #'   [layout_tbl_graph_circlepack()] for further details}
 #'   \item{`partition`}{Create icicle or sunburst charts, where each layer
-#'   subdivides the division given by the preceeding layer. See
+#'   subdivides the division given by the preceding layer. See
 #'   [layout_tbl_graph_partition()] for further details}
 #'   \item{`hive`}{Positions nodes on axes spreading out from the center
 #'   based on node attributes. See [layout_tbl_graph_hive()] for further
@@ -83,7 +83,7 @@
 #' @param ... Arguments passed on to the layout function.
 #'
 #' @return For `ggraph()` an object of class gg onto which layers, scales,
-#'   etc. can be added. For `create_layout()` an object inherting from
+#'   etc. can be added. For `create_layout()` an object inheriting from
 #'   `layout_ggraph`. `layout_ggraph` itself inherits from
 #'   `data.frame` and can be considered as such. The data.frame contains
 #'   the node positions in the `x` and `y` column along with

--- a/R/layout_circlepack.R
+++ b/R/layout_circlepack.R
@@ -1,7 +1,7 @@
 #' Calculate nodes as circles packed within their parent circle
 #'
 #' The circle packing algorithm is basically a treemap using circles instead of
-#' rectangles. Due to the nature of circles they cannot be packed as efficeintly
+#' rectangles. Due to the nature of circles they cannot be packed as efficiently
 #' leading to increased amount of "empty space" as compared to a treemap. This
 #' can be beneficial though, as the added empty space can aid in visually
 #' showing the hierarchy.

--- a/R/layout_dendrogram.R
+++ b/R/layout_dendrogram.R
@@ -1,6 +1,6 @@
 #' Apply a dendrogram layout to layout_tbl_graph
 #'
-#' This layout mimicks the [igraph::layout_as_tree()] algorithm
+#' This layout mimics the [igraph::layout_as_tree()] algorithm
 #' supplied by igraph, but puts all leaves at 0 and builds it up from there,
 #' instead of starting from the root and building it from there. The height of
 #' branch points are related to the maximum distance to an edge from the branch

--- a/R/layout_igraph.R
+++ b/R/layout_igraph.R
@@ -34,7 +34,7 @@
 #'   Consider using [layout_tbl_graph_linear()] with `circular=TRUE`
 #'   for more control. See [igraph::in_circle()]}
 #'   \item{`nicely`}{Tries to pick an appropriate layout. See
-#'   [igraph::nicely()] for a description of the simpe decision tree
+#'   [igraph::nicely()] for a description of the simple decision tree
 #'   it uses}
 #'   \item{`dh`}{Uses *Davidson and Harels* simulated annealing
 #'   algorithm to place nodes. See [igraph::with_dh()]}

--- a/R/layout_partition.R
+++ b/R/layout_partition.R
@@ -3,7 +3,7 @@
 #' The partition layout is a way to show hierarchical data in the same way as
 #' [layout_tbl_graph_treemap()]. Instead of subdividing the parent area
 #' the partition layout shows the division of a nodes children next to the area
-#' of the node itself. As such the node positions will be very reminicent of
+#' of the node itself. As such the node positions will be very reminiscent of
 #' a reingold-tilford tree layout but by plotting nodes as areas it better
 #' communicate the total weight of a node by summing up all its children.
 #' Often partition layouts are called icicle plots or sunburst diagrams (in case

--- a/R/layout_treemap.R
+++ b/R/layout_treemap.R
@@ -1,4 +1,4 @@
-#' Calculate nodes as rectangels subdividing that of their parent
+#' Calculate nodes as rectangles subdividing that of their parent
 #'
 #' A treemap is a space filling hierarchical layout that maps nodes to
 #' rectangles. The rectangles of the children of a node is packed into the

--- a/R/nodes.R
+++ b/R/nodes.R
@@ -9,7 +9,7 @@
 #' mandatory and is only required if additional data should be added to selected
 #' node layers.
 #'
-#' @param ... Additional data that should be cbind'ed togeether with the node
+#' @param ... Additional data that should be cbind'ed together with the node
 #' data.
 #'
 #' @return A data.frame with the node data as well of any additional data

--- a/R/scale_edge_width.R
+++ b/R/scale_edge_width.R
@@ -2,7 +2,7 @@
 #'
 #' This set of scales defines width scales for edge geoms. Of all the new edge
 #' scales defined in ggraph, this is the only one not having an equivalent in
-#' ggplot2. In essence it mimicks the use of size in
+#' ggplot2. In essence it mimics the use of size in
 #' [ggplot2::geom_line()] and related. As almost all edge
 #' representations are lines of some sort, edge_width will be used much more
 #' often than edge_size. It is not necessary to spell out that it is an edge

--- a/R/textAlong.R
+++ b/R/textAlong.R
@@ -33,9 +33,9 @@ textAlongGrob <- function(label, x = unit(0.5, "npc"), y = unit(0.5, "npc"),
              cl = "textalong")
     }
 }
-#' Text angeled acording to line
+#' Text angled according to line
 #'
-#' This function takes care of recalculating the angel of the text as the device
+#' This function takes care of recalculating the angle of the text as the device
 #' size changes
 #'
 #' @importFrom grid makeContent

--- a/R/tree_apply.R
+++ b/R/tree_apply.R
@@ -6,7 +6,7 @@
 #' recursion there is access to the node(s) that was/were called before and thus
 #' have already been through the function.
 #'
-#' @details The function is called with a set of predifined parameters along
+#' @details The function is called with a set of predefined parameters along
 #' with user defined ones. If `direction = 'down'` The parameters supplied
 #' automatically to the function are: `node`, `parent`, `depth`
 #' and `tree`, while if `direction = 'up'` the parameters are:

--- a/man/facet_graph.Rd
+++ b/man/facet_graph.Rd
@@ -70,7 +70,7 @@ This function is equivalent to \code{\link[ggplot2:facet_grid]{ggplot2::facet_gr
 allows for building a grid of small multiples where rows and columns
 correspond to a specific data value. While \code{\link[ggplot2:facet_grid]{ggplot2::facet_grid()}}
 could be used it would lead to unexpected results as it is not possible to
-specify whether you are refering to a node or an edge attribute. Furthermore
+specify whether you are referring to a node or an edge attribute. Furthermore
 \code{\link[ggplot2:facet_grid]{ggplot2::facet_grid()}} will draw edges in panels even though the
 panel does not contain both terminal nodes. \code{facet_graph} takes care of
 all of these issues, allowing you to define which data type the rows and

--- a/man/flare.Rd
+++ b/man/flare.Rd
@@ -7,7 +7,7 @@
 \format{A list of three data.frames describing the software structure of
 flare:
 \describe{
-\item{edges}{This data.frame maps the heirarchical structure of the class
+\item{edges}{This data.frame maps the hierarchical structure of the class
 hierarchy as an edgelist, with the class in \code{from} being the superclass
 of the class in \code{to}.}
 \item{vertices}{This data.frame gives additional information on the classes.

--- a/man/geom_conn_bundle.Rd
+++ b/man/geom_conn_bundle.Rd
@@ -4,7 +4,7 @@
 \alias{geom_conn_bundle}
 \alias{geom_conn_bundle2}
 \alias{geom_conn_bundle0}
-\title{Create heirarchical edge bundles between node connections}
+\title{Create hierarchical edge bundles between node connections}
 \usage{
 geom_conn_bundle(mapping = NULL, data = get_con(), position = "identity",
   arrow = NULL, lineend = "butt", show.legend = NA, n = 100,
@@ -57,7 +57,7 @@ an intrinsic hierarchical structure that defines the layout but is not shown.
 Connections between points (that is, not edges) are then drawn so that they
 loosely follows the underlying hierarchical structure. This results in a
 flow-like structure where lines that partly move in the same direction will
-be bundled togeether.
+be bundled together.
 }
 \note{
 In order to avoid excessive typing edge aesthetic names are

--- a/man/geom_edge_arc.Rd
+++ b/man/geom_edge_arc.Rd
@@ -31,7 +31,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -94,7 +94,7 @@ to the paired geom/stat.}
 \description{
 This geom is mainly intended for arc linear and circular diagrams (i.e. used
 together with \code{\link[=layout_tbl_graph_linear]{layout_tbl_graph_linear()}}), though it can be used
-elsewere. It draws edges as arcs with a hight proportional to the distance
+elsewhere. It draws edges as arcs with a height proportional to the distance
 between the nodes. Arcs are calculated as beziers. For linear layout the
 placement of control points are related to the \code{curvature} argument and
 the distance between the two nodes. For circular layout the control points
@@ -174,7 +174,7 @@ package, but does not allow for gradients along the edge.
 
 Often it is beneficial to stop the drawing of the edge before it reaches the
 node, for instance in cases where an arrow should be drawn and the arrowhead
-shouldn't lay ontop or below the node point. geom_edge_* and geom_edge_*2
+shouldn't lay on top or below the node point. geom_edge_* and geom_edge_*2
 supports this through the start_cap and end_cap aesthetics that takes a
 \code{\link[=geometry]{geometry()}} specification and dynamically caps the termini of the
 edges based on the given specifications. This means that if

--- a/man/geom_edge_density.Rd
+++ b/man/geom_edge_density.Rd
@@ -14,7 +14,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of

--- a/man/geom_edge_diagonal.Rd
+++ b/man/geom_edge_diagonal.Rd
@@ -31,7 +31,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -93,7 +93,7 @@ This geom draws edges as diagonal bezier curves as known from
 A diagonal in this context is a quadratic bezier with the control points
 positioned halfway between the start and end points but on the same axis.
 This produces a pleasing fan-in, fan-out line that is mostly relevant for
-heirarchical layouts as it implies an overall directionality in the plot.
+hierarchical layouts as it implies an overall directionality in the plot.
 }
 \section{Aesthetics}{
 
@@ -168,7 +168,7 @@ package, but does not allow for gradients along the edge.
 
 Often it is beneficial to stop the drawing of the edge before it reaches the
 node, for instance in cases where an arrow should be drawn and the arrowhead
-shouldn't lay ontop or below the node point. geom_edge_* and geom_edge_*2
+shouldn't lay on top or below the node point. geom_edge_* and geom_edge_*2
 supports this through the start_cap and end_cap aesthetics that takes a
 \code{\link[=geometry]{geometry()}} specification and dynamically caps the termini of the
 edges based on the given specifications. This means that if

--- a/man/geom_edge_elbow.Rd
+++ b/man/geom_edge_elbow.Rd
@@ -31,7 +31,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -171,7 +171,7 @@ package, but does not allow for gradients along the edge.
 
 Often it is beneficial to stop the drawing of the edge before it reaches the
 node, for instance in cases where an arrow should be drawn and the arrowhead
-shouldn't lay ontop or below the node point. geom_edge_* and geom_edge_*2
+shouldn't lay on top or below the node point. geom_edge_* and geom_edge_*2
 supports this through the start_cap and end_cap aesthetics that takes a
 \code{\link[=geometry]{geometry()}} specification and dynamically caps the termini of the
 edges based on the given specifications. This means that if

--- a/man/geom_edge_fan.Rd
+++ b/man/geom_edge_fan.Rd
@@ -30,7 +30,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -92,7 +92,7 @@ half-way between the nodes and at an angle dependent on the presence of
 parallel edges. This results in parallel edges being drawn in a
 non-overlapping fashion resembling the standard approach used in
 \code{\link[igraph:plot.igraph]{igraph::plot.igraph()}}. Before calculating the curvature the edges
-are sorted by direction so that edges goind the same way will be adjacent.
+are sorted by direction so that edges going the same way will be adjacent.
 This geom is currently the only choice for non-simple graphs if edges should
 not be overplotted.
 }
@@ -171,7 +171,7 @@ package, but does not allow for gradients along the edge.
 
 Often it is beneficial to stop the drawing of the edge before it reaches the
 node, for instance in cases where an arrow should be drawn and the arrowhead
-shouldn't lay ontop or below the node point. geom_edge_* and geom_edge_*2
+shouldn't lay on top or below the node point. geom_edge_* and geom_edge_*2
 supports this through the start_cap and end_cap aesthetics that takes a
 \code{\link[=geometry]{geometry()}} specification and dynamically caps the termini of the
 edges based on the given specifications. This means that if

--- a/man/geom_edge_hive.Rd
+++ b/man/geom_edge_hive.Rd
@@ -31,7 +31,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -92,7 +92,7 @@ to the paired geom/stat.}
 \description{
 This geom is only intended for use together with the hive layout. It draws
 edges between nodes as bezier curves, with the control points positioned at
-the same radi as the start or end point, and at a distance defined by the
+the same radii as the start or end point, and at a distance defined by the
 curvature argument.
 }
 \section{Aesthetics}{
@@ -166,7 +166,7 @@ package, but does not allow for gradients along the edge.
 
 Often it is beneficial to stop the drawing of the edge before it reaches the
 node, for instance in cases where an arrow should be drawn and the arrowhead
-shouldn't lay ontop or below the node point. geom_edge_* and geom_edge_*2
+shouldn't lay on top or below the node point. geom_edge_* and geom_edge_*2
 supports this through the start_cap and end_cap aesthetics that takes a
 \code{\link[=geometry]{geometry()}} specification and dynamically caps the termini of the
 edges based on the given specifications. This means that if

--- a/man/geom_edge_link.Rd
+++ b/man/geom_edge_link.Rd
@@ -30,7 +30,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -104,7 +104,7 @@ package, but does not allow for gradients along the edge.
 
 Often it is beneficial to stop the drawing of the edge before it reaches the
 node, for instance in cases where an arrow should be drawn and the arrowhead
-shouldn't lay ontop or below the node point. geom_edge_* and geom_edge_*2
+shouldn't lay on top or below the node point. geom_edge_* and geom_edge_*2
 supports this through the start_cap and end_cap aesthetics that takes a
 \code{\link[=geometry]{geometry()}} specification and dynamically caps the termini of the
 edges based on the given specifications. This means that if

--- a/man/geom_edge_loop.Rd
+++ b/man/geom_edge_loop.Rd
@@ -22,7 +22,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -145,7 +145,7 @@ package, but does not allow for gradients along the edge.
 
 Often it is beneficial to stop the drawing of the edge before it reaches the
 node, for instance in cases where an arrow should be drawn and the arrowhead
-shouldn't lay ontop or below the node point. geom_edge_* and geom_edge_*2
+shouldn't lay on top or below the node point. geom_edge_* and geom_edge_*2
 supports this through the start_cap and end_cap aesthetics that takes a
 \code{\link[=geometry]{geometry()}} specification and dynamically caps the termini of the
 edges based on the given specifications. This means that if

--- a/man/geom_edge_point.Rd
+++ b/man/geom_edge_point.Rd
@@ -14,7 +14,7 @@ circular are mapped to x, y, xend, yend, edge.id and circular in the edge
 data.}
 
 \item{data}{The return of a call to \code{get_edges()} or a data.frame
-giving edges in corrent format (see details for for guidance on the format).
+giving edges in correct format (see details for for guidance on the format).
 See \code{\link[=get_edges]{get_edges()}} for more details on edge extraction.}
 
 \item{position}{Position adjustment, either as a string, or the result of

--- a/man/geom_node_circle.Rd
+++ b/man/geom_node_circle.Rd
@@ -43,7 +43,7 @@ to the paired geom/stat.}
 \description{
 This geom is equivalent in functionality to \code{\link[ggforce:geom_circle]{ggforce::geom_circle()}}
 and allows for plotting of nodes as circles with a radius scaled by the
-coordinate system. Beceause of the geoms reliance on the coordinate system
+coordinate system. Because of the geoms reliance on the coordinate system
 it will only produce true circles when combined with
 \code{\link[ggplot2:coord_fixed]{ggplot2::coord_fixed()}}
 }

--- a/man/get_con.Rd
+++ b/man/get_con.Rd
@@ -21,14 +21,14 @@ connections
 }
 \description{
 Connections within the ggraph terminology are links between nodes that are
-not part of the network structure itself. In that sense connections does not
+not part of the network structure itself. In that sense connections do not
 affect the layout calculation in any way and will not be drawn by the
 standard \code{geom_edge_*} functions. A connection does not need to only be
 defined by a start and end node, but can include intermediary nodes.
 \code{get_con} helps in creating connection data by letting you specify start
-and end node and automatically find the shortest path within the graph
+and end nodes and automatically finds the shortest path within the graph
 structure that connects the given points. If this is not what is needed it is
-also possible to supply a list of vectors giving node indexes that defines a
+also possible to supply a list of vectors giving node indices that define a
 connection.
 }
 \seealso{

--- a/man/get_edges.Rd
+++ b/man/get_edges.Rd
@@ -60,7 +60,7 @@ end node.}
 \item{long}{In this format each edge consists of two rows with matching
 \code{edge.id} value. The start and end position are both encoded in the
 \code{x} and \code{y} column. The relative position of the rows determines
-which is the start and end node, the first occuring being the start node.
+which is the start and end node, the first occurring being the start node.
 If node parameters are added to the edge data the name of the parameters
 will be prefixed with \code{node.}.}
 }
@@ -74,7 +74,7 @@ format (see above).
 If the graph is not simple (it contains at most one edge between each node
 pair) it can be collapsed so either all edges between two nodes or all edges
 of the same direction between two nodes are merged. The edge parameters are
-taken from the first occuring edge, so if some more sophisticated summary is
+taken from the first occurring edge, so if some more sophisticated summary is
 needed it is suggested that the graph be tidied up before plotting with
 ggraph.
 }

--- a/man/get_nodes.Rd
+++ b/man/get_nodes.Rd
@@ -7,7 +7,7 @@
 get_nodes(...)
 }
 \arguments{
-\item{...}{Additional data that should be cbind'ed togeether with the node
+\item{...}{Additional data that should be cbind'ed together with the node
 data.}
 }
 \value{

--- a/man/ggraph-extensions.Rd
+++ b/man/ggraph-extensions.Rd
@@ -60,7 +60,7 @@ Many of the \code{geom_edge_*} geoms comes in different flavors dependent on
 the functionality required. There will always be a base geom and some will
 have a \code{geom_edge_*0} and \code{geom_edge_*2} version. The base geom
 will, in the case of multiple versions, draw the edge as a sequence of small
-segments. The different aesthetics will be repeated for each seqgment and a
+segments. The different aesthetics will be repeated for each segment and a
 counter will be added the enumerates the progression of segments, so that a
 gradient of colour or size can be added along the edge by assigning the
 respective aesthetic to \code{..index..}. \code{geom_edge_*2} will also draw

--- a/man/ggraph.Rd
+++ b/man/ggraph.Rd
@@ -36,7 +36,7 @@ representation. Only possible for some layouts. Defaults to \code{FALSE}}
 }
 \value{
 For \code{ggraph()} an object of class gg onto which layers, scales,
-etc. can be added. For \code{create_layout()} an object inherting from
+etc. can be added. For \code{create_layout()} an object inheriting from
 \code{layout_ggraph}. \code{layout_ggraph} itself inherits from
 \code{data.frame} and can be considered as such. The data.frame contains
 the node positions in the \code{x} and \code{y} column along with
@@ -53,7 +53,7 @@ It takes care of setting up the plot object along with creating the layout
 for the plot based on the graph and the specification passed in.
 Alternatively a layout can be prepared in advance using
 \code{create_layout} and passed as the data argument. See \emph{Details} for
-a desciption of all available layouts.
+a description of all available layouts.
 }
 \details{
 Following is a short description of the different layout types available in
@@ -97,7 +97,7 @@ space-filing subdivision of rectangles showing a weighted hierarchy. See
 within circles. Conceptually equal to treemaps. See
 \code{\link[=layout_tbl_graph_circlepack]{layout_tbl_graph_circlepack()}} for further details}
 \item{\code{partition}}{Create icicle or sunburst charts, where each layer
-subdivides the division given by the preceeding layer. See
+subdivides the division given by the preceding layer. See
 \code{\link[=layout_tbl_graph_partition]{layout_tbl_graph_partition()}} for further details}
 \item{\code{hive}}{Positions nodes on axes spreading out from the center
 based on node attributes. See \code{\link[=layout_tbl_graph_hive]{layout_tbl_graph_hive()}} for further

--- a/man/highschool.Rd
+++ b/man/highschool.Rd
@@ -11,7 +11,7 @@
 \item{year}{The year the friendship was reported}
 }}
 \source{
-Coleman, J. S. \emph{Introduction to Mathermatical Sociology}. New York: Free
+Coleman, J. S. \emph{Introduction to Mathematical Sociology}. New York: Free
 Press, pp.450-451.
 }
 \usage{

--- a/man/layout_tbl_graph_circlepack.Rd
+++ b/man/layout_tbl_graph_circlepack.Rd
@@ -30,7 +30,7 @@ variables in the tbl_graph object.
 }
 \description{
 The circle packing algorithm is basically a treemap using circles instead of
-rectangles. Due to the nature of circles they cannot be packed as efficeintly
+rectangles. Due to the nature of circles they cannot be packed as efficiently
 leading to increased amount of "empty space" as compared to a treemap. This
 can be beneficial though, as the added empty space can aid in visually
 showing the hierarchy.

--- a/man/layout_tbl_graph_dendrogram.Rd
+++ b/man/layout_tbl_graph_dendrogram.Rd
@@ -34,7 +34,7 @@ A data.frame with the columns \code{x}, \code{y}, \code{circular}, \code{depth} 
 tbl_graph
 }
 \description{
-This layout mimicks the \code{\link[igraph:layout_as_tree]{igraph::layout_as_tree()}} algorithm
+This layout mimics the \code{\link[igraph:layout_as_tree]{igraph::layout_as_tree()}} algorithm
 supplied by igraph, but puts all leaves at 0 and builds it up from there,
 instead of starting from the root and building it from there. The height of
 branch points are related to the maximum distance to an edge from the branch

--- a/man/layout_tbl_graph_igraph.Rd
+++ b/man/layout_tbl_graph_igraph.Rd
@@ -65,7 +65,7 @@ around it. See \code{\link[igraph:as_star]{igraph::as_star()}}}
 Consider using \code{\link[=layout_tbl_graph_linear]{layout_tbl_graph_linear()}} with \code{circular=TRUE}
 for more control. See \code{\link[igraph:in_circle]{igraph::in_circle()}}}
 \item{\code{nicely}}{Tries to pick an appropriate layout. See
-\code{\link[igraph:nicely]{igraph::nicely()}} for a description of the simpe decision tree
+\code{\link[igraph:nicely]{igraph::nicely()}} for a description of the simple decision tree
 it uses}
 \item{\code{dh}}{Uses \emph{Davidson and Harels} simulated annealing
 algorithm to place nodes. See \code{\link[igraph:with_dh]{igraph::with_dh()}}}

--- a/man/layout_tbl_graph_partition.Rd
+++ b/man/layout_tbl_graph_partition.Rd
@@ -48,7 +48,7 @@ variables in the tbl_graph object.
 The partition layout is a way to show hierarchical data in the same way as
 \code{\link[=layout_tbl_graph_treemap]{layout_tbl_graph_treemap()}}. Instead of subdividing the parent area
 the partition layout shows the division of a nodes children next to the area
-of the node itself. As such the node positions will be very reminicent of
+of the node itself. As such the node positions will be very reminiscent of
 a reingold-tilford tree layout but by plotting nodes as areas it better
 communicate the total weight of a node by summing up all its children.
 Often partition layouts are called icicle plots or sunburst diagrams (in case

--- a/man/layout_tbl_graph_treemap.Rd
+++ b/man/layout_tbl_graph_treemap.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/layout_treemap.R
 \name{layout_tbl_graph_treemap}
 \alias{layout_tbl_graph_treemap}
-\title{Calculate nodes as rectangels subdividing that of their parent}
+\title{Calculate nodes as rectangles subdividing that of their parent}
 \usage{
 layout_tbl_graph_treemap(graph, algorithm = "split", weight = NULL,
   circular = FALSE, sort.by = NULL, direction = "out", height = 1,

--- a/man/makeContent.cappedpathgrob.Rd
+++ b/man/makeContent.cappedpathgrob.Rd
@@ -7,7 +7,7 @@
 \method{makeContent}{cappedpathgrob}(x)
 }
 \description{
-This function takes care of updating which parts of the paths gets removed
+This function takes care of updating which parts of the paths get removed
 when the device dimensions are updated.
 }
 \keyword{internal}

--- a/man/makeContent.textalong.Rd
+++ b/man/makeContent.textalong.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/textAlong.R
 \name{makeContent.textalong}
 \alias{makeContent.textalong}
-\title{Text angeled acording to line}
+\title{Text angled according to line}
 \usage{
 \method{makeContent}{textalong}(x)
 }
 \description{
-This function takes care of recalculating the angel of the text as the device
+This function takes care of recalculating the angle of the text as the device
 size changes
 }
 \keyword{internal}

--- a/man/scale_edge_colour.Rd
+++ b/man/scale_edge_colour.Rd
@@ -171,7 +171,7 @@ index into the list of palettes of appropriate \code{type}}
 
 \item{values}{if colours should not be evenly positioned along the gradient
 this vector gives the position (between 0 and 1) for each colour in the
-\code{colours} vector. See \code{\link{rescale}} for a convience function
+\code{colours} vector. See \code{\link{rescale}} for a convenience function
 to map an arbitrary range to between 0 and 1.}
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -

--- a/man/scale_edge_fill.Rd
+++ b/man/scale_edge_fill.Rd
@@ -125,7 +125,7 @@ index into the list of palettes of appropriate \code{type}}
 
 \item{values}{if colours should not be evenly positioned along the gradient
 this vector gives the position (between 0 and 1) for each colour in the
-\code{colours} vector. See \code{\link{rescale}} for a convience function
+\code{colours} vector. See \code{\link{rescale}} for a convenience function
 to map an arbitrary range to between 0 and 1.}
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -

--- a/man/scale_edge_width.Rd
+++ b/man/scale_edge_width.Rd
@@ -97,7 +97,7 @@ A ggproto object inheriting from \code{Scale}
 \description{
 This set of scales defines width scales for edge geoms. Of all the new edge
 scales defined in ggraph, this is the only one not having an equivalent in
-ggplot2. In essence it mimicks the use of size in
+ggplot2. In essence it mimics the use of size in
 \code{\link[ggplot2:geom_line]{ggplot2::geom_line()}} and related. As almost all edge
 representations are lines of some sort, edge_width will be used much more
 often than edge_size. It is not necessary to spell out that it is an edge

--- a/man/scale_type.geometry.Rd
+++ b/man/scale_type.geometry.Rd
@@ -7,7 +7,7 @@
 \method{scale_type}{geometry}(x)
 }
 \description{
-This functions is quite useless as geometry is not meant to be scaled, but it
+This function is quite useless as geometry is not meant to be scaled, but it
 is a requirement for ggplot2 to handle it correctly.
 }
 \keyword{internal}

--- a/man/tree_apply.Rd
+++ b/man/tree_apply.Rd
@@ -46,7 +46,7 @@ recursion there is access to the node(s) that was/were called before and thus
 have already been through the function.
 }
 \details{
-The function is called with a set of predifined parameters along
+The function is called with a set of predefined parameters along
 with user defined ones. If \code{direction = 'down'} The parameters supplied
 automatically to the function are: \code{node}, \code{parent}, \code{depth}
 and \code{tree}, while if \code{direction = 'up'} the parameters are:


### PR DESCRIPTION
In addition to #111, corrected some of the documentation spelling.

I haven't run `devtools::document()` as this caused a number of other changes to the `man` pages unrelated to this PR so that still needs to be done.
They've only been updated using `document` with changes from this PR.