### PR TITLE
Fix travis build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,8 @@ Suggests: network,
     knitr,
     rmarkdown,
     purrr,
-    tibble
+    tibble,
+    seriation
 Remotes: tidyverse/ggplot2,
     thomasp85/tidygraph
 LinkingTo: Rcpp


### PR DESCRIPTION
The `seriation` package is used in the `tidygraph.Rmd` vignette via `tidygraph::node_rank_leafsort()`.

`tidygraph` suggests this package however `ggraph` does not.