### PR TITLE
Bump version and date past CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ggraph
 Type: Package
 Title: An Implementation of Grammar of Graphics for Graphs and Networks
-Version: 1.0.0.9999
-Date: 2017-02-23
+Version: 1.0.1.9999
+Date: 2018-01-29
 Authors@R:
     person(given = "Thomas Lin",
            family = "Pedersen",


### PR DESCRIPTION
GitHub dev version is currently behind latest CRAN version which throws off package manages (eg. packrat)

cc thomasp85/tidygraph#62