### PR TITLE
Bump required ggplot2 to 3.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ LinkingTo: Rcpp
 RoxygenNote: 6.0.1.9000
 Depends:
     R (>= 2.10),
-    ggplot2 (>= 2.0.0)
+    ggplot2 (>= 3.0.0)
 VignetteBuilder: knitr
 URL: https://github.com/thomasp85/ggraph
 BugReports: https://github.com/thomasp85/ggraph/issues


### PR DESCRIPTION
Closes #147.

This PR bumps the required ggplot2 version to 3.0.0, as this version of ggraph uses some functions introduced in that version.