### PR TITLE
bump version higher than CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggraph
 Type: Package
 Title: An Implementation of Grammar of Graphics for Graphs and Networks
-Version: 1.0.1.9999
+Version: 1.0.2.9999
 Date: 2017-02-23
 Authors@R:
     person(given = "Thomas Lin",


### PR DESCRIPTION
Current CRAN version is 1.0.2, so using `update.packages()` after installing from GitHub actually downgrades this package...