### PR TITLE
Generalize the fix for repeated labels (fix #159)

### DIFF
--- a/R/geom_edge.R
+++ b/R/geom_edge.R
@@ -123,18 +123,12 @@ GeomEdgePath <- ggproto('GeomEdgePath', GeomPath,
       label_y1 <- data$y[angle_end + edge_start]
       lab <- as.character(label_data$label)
       if (label_parse) {
-        lab <-
-          unname(sapply(
-            X=lab,
-            FUN=function(x) {
-              ret <- as.character(parse(text=x))
-              if (length(ret)) {
-                ret
-              } else {
-                ""
-              }
-            }
-          ))
+        lab_expressions <- sapply(X=lab, FUN=str2expression)
+        lab_len <- sapply(X=lab_expressions, FUN=length)
+        if (any(lab_len == 0)) {
+          lab[lab_len == 0] <- "` `"
+          lab <- sapply(X=lab, FUN=str2expression)
+        }
       }
       label_grob <- textAlongGrob(
         lab, label_data$x, label_data$y,

--- a/R/geom_edge.R
+++ b/R/geom_edge.R
@@ -123,7 +123,18 @@ GeomEdgePath <- ggproto('GeomEdgePath', GeomPath,
       label_y1 <- data$y[angle_end + edge_start]
       lab <- as.character(label_data$label)
       if (label_parse) {
-        lab[lab != ''] <- parse(text = lab)
+        lab <-
+          unname(sapply(
+            X=lab,
+            FUN=function(x) {
+              ret <- as.character(parse(text=x))
+              if (length(ret)) {
+                ret
+              } else {
+                ""
+              }
+            }
+          ))
       }
       label_grob <- textAlongGrob(
         lab, label_data$x, label_data$y,


### PR DESCRIPTION
Fix #159 

The current fix for #159, corrects the specific case of empty strings, but there are more general cases that result in empty parsing.  I've generalized the fix.  An example of the issue is in the reprex below.

``` r
lab <- c("A", " ", "\t", "\n", "B")
current <- lab
current[current != ''] <- parse(text=lab)
#> Warning in current[current != ""] <- parse(text = lab): number of items to
#> replace is not a multiple of replacement length
suggested <-
  unname(sapply(
    X=lab,
    FUN=function(x) {
      ret <- as.character(parse(text=x))
      if (length(ret)) {
        ret
      } else {
        ""
      }
    }
  ))
print(current)
#> expression(A, B, A, B, A)
print(suggested)
#> [1] "A" ""  ""  ""  "B"
```

<sup>Created on 2019-08-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
