### PR TITLE
Fix crash when using `start_cap = circle(.data$node1.size, unit="native")`

### DIFF
--- a/R/geom_edge.R
+++ b/R/geom_edge.R
@@ -44,7 +44,7 @@ GeomEdgePath <- ggproto('GeomEdgePath', GeomPath,
       if (any(attr(start_cap, 'unit') == 'native') ||
         any(attr(start_cap2, 'unit') == 'native')) {
         recalc <- coord$transform(
-          new_data_Frame(list(x = as.vector(start_cap), y = as.vector(start_cap2))),
+          new_data_frame(list(x = as.vector(start_cap), y = as.vector(start_cap2))),
           panel_scales
         )
         start_cap[attr(start_cap, 'unit') == 'native'] <- unit(recalc$x - zero$x, 'npc')


### PR DESCRIPTION
In the current master branch (14402216487df4e3c81e6c3eabbcb4fe2468e5dc), the following code crashes due to a misspelled function name:
```R
data.frame(
  from = c("A"),
  to = c("B")
) %>%
  igraph::graph_from_data_frame() %>%
  ggraph(layout = "circle") +
    geom_edge_link(
      start_cap = circle(.2, unit="native"), # comment out this line to avoid crash
      end_cap = circle(.2, unit="native"),
      arrow = arrow()
    ) +
    geom_node_circle(aes(r = .2)) +
    geom_node_text(aes(label = name)) +
    coord_fixed()
```
This PR fixes the spelling.