### PR TITLE
prevent the usage of negative weights in Fruchterman-Reingold layout with igraph

### DIFF
--- a/vignettes/tidygraph.Rmd
+++ b/vignettes/tidygraph.Rmd
@@ -96,7 +96,7 @@ node and edge parameters affecting layouts as it is not necessary to modify the
 underlying graph but only the plotting code, e.g.:
 
 ```{r}
-ggraph(graph, layout = 'fr', weights = log(weight)) + 
+ggraph(graph, layout = 'fr', weights = -log(weight)) + 
   geom_edge_link() + 
   geom_node_point()
 ```


### PR DESCRIPTION
A recent change in `igraph` 1.3.3 added a validation step to the weights of the graph when using the Fruchterman-Reingold, Kamada-Kawai or DrL layouts. In particular, none of these methods make sense with non-positive weights, so igraph now explicitly prevents non-positive weights and throws an error if it encounters one. As a consequence, the `tidygraph.Rmd` vignette broke in `ggraph`. This PR fixes the issue by using `-log(weight)` in the vignette instead of `log(weight)` to ensure that all weights are positive.