### PR TITLE
Upkeep: `trans` to `transform`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     sfnetworks
 LinkingTo: 
     cpp11
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Depends:
     R (>= 2.10),
     ggplot2 (>= 3.5.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggraph (development version)
 
+* Updated `scale_*(trans)` to `scale_*(transform)` in keeping with ggplot2.
+
 # ggraph 2.2.2
 
 * Fixed a bug in the collapse functionality of `get_edges()` (#362)

--- a/R/scale_edge_size.R
+++ b/R/scale_edge_size.R
@@ -31,8 +31,9 @@ scale_edge_size_continuous <- function(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 ) {
   sc <- scale_size_continuous(
     name = name,
@@ -40,6 +41,7 @@ scale_edge_size_continuous <- function(
     labels = labels,
     limits = limits,
     range = range,
+    transform = transform,
     trans = trans,
     guide = guide
   )
@@ -57,8 +59,9 @@ scale_edge_radius <- function(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 ) {
   sc <- scale_radius(
     name = name,
@@ -66,6 +69,7 @@ scale_edge_radius <- function(
     labels = labels,
     limits = limits,
     range = range,
+    transform = transform,
     trans = trans,
     guide = guide
   )
@@ -100,8 +104,9 @@ scale_edge_size_binned <- function(
   range = c(1, 6),
   n.breaks = NULL,
   nice.breaks = TRUE,
-  trans = "identity",
-  guide = "bins"
+  transform = "identity",
+  guide = "bins",
+  trans = deprecated()
 ) {
   sc <- scale_size_binned(
     name = name,
@@ -111,6 +116,7 @@ scale_edge_size_binned <- function(
     range = range,
     n.breaks = n.breaks,
     nice.breaks = nice.breaks,
+    transform = transform,
     trans = trans,
     guide = guide
   )

--- a/R/scale_edge_width.R
+++ b/R/scale_edge_width.R
@@ -29,8 +29,9 @@ scale_edge_width_continuous <- function(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 ) {
   sc <- scale_radius(
     name = name,
@@ -39,6 +40,7 @@ scale_edge_width_continuous <- function(
     limits = limits,
     range = range,
     trans = trans,
+    transform = transform,
     guide = guide
   )
   sc$scale_name <- 'width_c'
@@ -74,8 +76,9 @@ scale_edge_width_binned <- function(
   range = c(1, 6),
   n.breaks = NULL,
   nice.breaks = TRUE,
-  trans = "identity",
-  guide = "bins"
+  transform = "identity",
+  guide = "bins",
+  trans = deprecated()
 ) {
   sc <- scale_size_binned(
     name = name,
@@ -85,6 +88,7 @@ scale_edge_width_binned <- function(
     range = range,
     n.breaks = n.breaks,
     nice.breaks = nice.breaks,
+    transform = transform,
     trans = trans,
     guide = guide
   )

--- a/R/scale_edge_width.R
+++ b/R/scale_edge_width.R
@@ -43,7 +43,6 @@ scale_edge_width_continuous <- function(
     transform = transform,
     guide = guide
   )
-  sc$scale_name <- 'width_c'
   sc$aesthetics <- 'edge_width'
   sc
 }
@@ -60,7 +59,6 @@ scale_edge_width_discrete <- function(...) {
     "Using {.field edge_width} for a discrete variable is not advised."
   )
   sc <- scale_size_ordinal(...)
-  sc$scale_name <- 'width_d'
   sc$aesthetics <- 'edge_width'
   sc
 }
@@ -92,7 +90,6 @@ scale_edge_width_binned <- function(
     trans = trans,
     guide = guide
   )
-  sc$scale_name <- 'width_b'
   sc$aesthetics <- 'edge_width'
   sc
 }

--- a/R/scale_label_size.R
+++ b/R/scale_label_size.R
@@ -23,8 +23,9 @@ scale_label_size_continuous <- function(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 ) {
   sc <- scale_size_continuous(
     name = name,
@@ -67,8 +68,9 @@ scale_label_size_binned <- function(
   range = c(1, 6),
   n.breaks = NULL,
   nice.breaks = TRUE,
-  trans = "identity",
-  guide = "bins"
+  transform = "identity",
+  guide = "bins",
+  trans = deprecated()
 ) {
   sc <- scale_size_binned(
     name = name,
@@ -78,6 +80,7 @@ scale_label_size_binned <- function(
     range = range,
     n.breaks = n.breaks,
     nice.breaks = nice.breaks,
+    transform = transform,
     trans = trans,
     guide = guide
   )

--- a/man/scale_edge_size.Rd
+++ b/man/scale_edge_size.Rd
@@ -18,8 +18,9 @@ scale_edge_size_continuous(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 )
 
 scale_edge_radius(
@@ -28,8 +29,9 @@ scale_edge_radius(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 )
 
 scale_edge_size(
@@ -38,8 +40,9 @@ scale_edge_size(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 )
 
 scale_edge_size_discrete(...)
@@ -52,8 +55,9 @@ scale_edge_size_binned(
   range = c(1, 6),
   n.breaks = NULL,
   nice.breaks = TRUE,
-  trans = "identity",
-  guide = "bins"
+  transform = "identity",
+  guide = "bins",
+  trans = deprecated()
 )
 
 scale_edge_size_area(..., max_size = 6)
@@ -112,11 +116,24 @@ If the purpose is to zoom, use the limit argument in the coordinate system
 \item{range}{a numeric vector of length 2 that specifies the minimum and
 maximum size of the plotting symbol after transformation.}
 
-\item{trans}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated in favour of
-\code{transform}.}
+\item{transform}{For continuous scales, the name of a transformation object
+or the object itself. Built-in transformations include "asn", "atanh",
+"boxcox", "date", "exp", "hms", "identity", "log", "log10", "log1p", "log2",
+"logit", "modulus", "probability", "probit", "pseudo_log", "reciprocal",
+"reverse", "sqrt" and "time".
+
+A transformation object bundles together a transform, its inverse,
+and methods for generating breaks and labels. Transformation objects
+are defined in the scales package, and are called \verb{transform_<name>}. If
+transformations require arguments, you can call them from the scales
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[ggplot2:guides]{guides()}} for more information.}
+
+\item{trans}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated in favour of
+\code{transform}.}
 
 \item{...}{
   Arguments passed on to \code{\link[ggplot2:continuous_scale]{continuous_scale}}

--- a/man/scale_edge_width.Rd
+++ b/man/scale_edge_width.Rd
@@ -15,8 +15,9 @@ scale_edge_width_continuous(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 )
 
 scale_edge_width(
@@ -25,8 +26,9 @@ scale_edge_width(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 )
 
 scale_edge_width_discrete(...)
@@ -39,8 +41,9 @@ scale_edge_width_binned(
   range = c(1, 6),
   n.breaks = NULL,
   nice.breaks = TRUE,
-  trans = "identity",
-  guide = "bins"
+  transform = "identity",
+  guide = "bins",
+  trans = deprecated()
 )
 
 scale_edge_width_manual(..., values, breaks = waiver(), na.value = NA)
@@ -95,11 +98,24 @@ If the purpose is to zoom, use the limit argument in the coordinate system
 \item{range}{a numeric vector of length 2 that specifies the minimum and
 maximum size of the plotting symbol after transformation.}
 
-\item{trans}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated in favour of
-\code{transform}.}
+\item{transform}{For continuous scales, the name of a transformation object
+or the object itself. Built-in transformations include "asn", "atanh",
+"boxcox", "date", "exp", "hms", "identity", "log", "log10", "log1p", "log2",
+"logit", "modulus", "probability", "probit", "pseudo_log", "reciprocal",
+"reverse", "sqrt" and "time".
+
+A transformation object bundles together a transform, its inverse,
+and methods for generating breaks and labels. Transformation objects
+are defined in the scales package, and are called \verb{transform_<name>}. If
+transformations require arguments, you can call them from the scales
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[ggplot2:guides]{guides()}} for more information.}
+
+\item{trans}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated in favour of
+\code{transform}.}
 
 \item{...}{
   Arguments passed on to \code{\link[ggplot2:continuous_scale]{continuous_scale}}

--- a/man/scale_label_size.Rd
+++ b/man/scale_label_size.Rd
@@ -15,8 +15,9 @@ scale_label_size_continuous(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 )
 
 scale_label_size(
@@ -25,8 +26,9 @@ scale_label_size(
   labels = waiver(),
   limits = NULL,
   range = c(1, 6),
-  trans = "identity",
-  guide = "legend"
+  transform = "identity",
+  guide = "legend",
+  trans = deprecated()
 )
 
 scale_label_size_discrete(...)
@@ -39,8 +41,9 @@ scale_label_size_binned(
   range = c(1, 6),
   n.breaks = NULL,
   nice.breaks = TRUE,
-  trans = "identity",
-  guide = "bins"
+  transform = "identity",
+  guide = "bins",
+  trans = deprecated()
 )
 
 scale_label_size_manual(..., values, breaks = waiver(), na.value = NA)
@@ -95,11 +98,24 @@ If the purpose is to zoom, use the limit argument in the coordinate system
 \item{range}{a numeric vector of length 2 that specifies the minimum and
 maximum size of the plotting symbol after transformation.}
 
-\item{trans}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated in favour of
-\code{transform}.}
+\item{transform}{For continuous scales, the name of a transformation object
+or the object itself. Built-in transformations include "asn", "atanh",
+"boxcox", "date", "exp", "hms", "identity", "log", "log10", "log1p", "log2",
+"logit", "modulus", "probability", "probit", "pseudo_log", "reciprocal",
+"reverse", "sqrt" and "time".
+
+A transformation object bundles together a transform, its inverse,
+and methods for generating breaks and labels. Transformation objects
+are defined in the scales package, and are called \verb{transform_<name>}. If
+transformations require arguments, you can call them from the scales
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[ggplot2:guides]{guides()}} for more information.}
+
+\item{trans}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated in favour of
+\code{transform}.}
 
 \item{...}{
   Arguments passed on to \code{\link[ggplot2:continuous_scale]{continuous_scale}}


### PR DESCRIPTION
We already depend on ggplot2 3.5.0 which was also when this change was introduced.