### PR TITLE
Size aesthetic to linewidth

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     sfnetworks
 LinkingTo: 
     cpp11
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Depends:
     R (>= 2.10),
     ggplot2 (>= 3.5.0)

--- a/R/geom_node_arc_bar.R
+++ b/R/geom_node_arc_bar.R
@@ -6,7 +6,7 @@
 #' as created with circular partition layouts
 #'
 #' @section Aesthetics:
-#' `geom_node_point` understand the following aesthetics. Bold aesthetics are
+#' `geom_node_arc_bar` understand the following aesthetics. Bold aesthetics are
 #' automatically set, but can be overwritten.
 #'
 #' - **x0**
@@ -18,9 +18,8 @@
 #' - alpha
 #' - colour
 #' - fill
-#' - shape
-#' - size
-#' - stroke
+#' - linewidth
+#' - linetype
 #' - filter
 #'
 #' @inheritParams ggforce::geom_circle

--- a/R/geom_node_circle.R
+++ b/R/geom_node_circle.R
@@ -16,9 +16,8 @@
 #' - alpha
 #' - colour
 #' - fill
-#' - shape
-#' - size
-#' - stroke
+#' - linewidth
+#' - linetype
 #' - filter
 #'
 #' @inheritParams ggforce::geom_circle

--- a/R/geom_node_range.R
+++ b/R/geom_node_range.R
@@ -4,7 +4,7 @@
 #' layout for showing the horizontal span of each node.
 #'
 #' @section Aesthetics:
-#' `geom_node_point` understand the following aesthetics. Bold aesthetics are
+#' `geom_node_range` understand the following aesthetics. Bold aesthetics are
 #' automatically set, but can be overwritten.
 #'
 #' - **x**
@@ -14,7 +14,7 @@
 #' - alpha
 #' - colour
 #' - linetype
-#' - size
+#' - linewidth
 #' - filter
 #'
 #' @inheritParams ggplot2::geom_linerange

--- a/R/geom_node_tile.R
+++ b/R/geom_node_tile.R
@@ -2,12 +2,10 @@
 #'
 #' A treemap is a space filling layout that recursively divides a rectangle to
 #' the children of the node. Often only the leaf nodes are drawn as nodes higher
-#' up in the hierarchy would obscure what is below. `geom_treemap` is a
-#' shorthand for `geom_node_treemap` as node is implicit in the case of
-#' treemap drawing
+#' up in the hierarchy would obscure what is below.
 #'
 #' @section Aesthetics:
-#' `geom_treemap` understand the following aesthetics. Bold aesthetics are
+#' `geom_node_tile` understand the following aesthetics. Bold aesthetics are
 #' automatically set, but can be overwritten.
 #'
 #' - **x**
@@ -17,8 +15,8 @@
 #' - alpha
 #' - colour
 #' - fill
-#' - size
-#' - stroke
+#' - linewidth
+#' - linetype
 #' - filter
 #'
 #' @inheritParams ggplot2::geom_tile

--- a/R/geom_node_voronoi.R
+++ b/R/geom_node_voronoi.R
@@ -15,9 +15,8 @@
 #' - alpha
 #' - colour
 #' - fill
-#' - shape
-#' - size
-#' - stroke
+#' - linewidth
+#' - linetype
 #' - filter
 #'
 #' @inheritParams ggforce::geom_voronoi_tile

--- a/R/scale_edge_width.R
+++ b/R/scale_edge_width.R
@@ -1,12 +1,10 @@
 #' Edge width scales
 #'
-#' This set of scales defines width scales for edge geoms. Of all the new edge
-#' scales defined in ggraph, this is the only one not having an equivalent in
-#' ggplot2. In essence it mimics the use of size in
-#' [ggplot2::geom_line()] and related. As almost all edge
-#' representations are lines of some sort, edge_width will be used much more
-#' often than edge_size. It is not necessary to spell out that it is an edge
-#' scale as the geom knows if it is drawing an edge. Just write `width` and
+#' This set of scales defines width scales for edge geoms. In essence it mimics
+#' the use of `linewidth` in [ggplot2::geom_line()] and related. As almost all
+#' edge representations are lines of some sort, `edge_width` will be used much
+#' more often than `edge_size`. It is not necessary to spell out that it is an
+#' edge scale as the geom knows if it is drawing an edge. Just write `width` and
 #' not `edge_width` in the call to geoms.
 #'
 #' @return A ggproto object inheriting from `Scale`
@@ -20,7 +18,7 @@ NULL
 
 #' @rdname scale_edge_width
 #'
-#' @inheritParams ggplot2::scale_size_continuous
+#' @inheritParams ggplot2::scale_linewidth_continuous
 #'
 #' @export
 scale_edge_width_continuous <- function(
@@ -32,7 +30,7 @@ scale_edge_width_continuous <- function(
   trans = "identity",
   guide = "legend"
 ) {
-  sc <- scale_radius(
+  sc <- scale_linewidth_continuous(
     name = name,
     breaks = breaks,
     labels = labels,
@@ -41,7 +39,6 @@ scale_edge_width_continuous <- function(
     trans = trans,
     guide = guide
   )
-  sc$scale_name <- 'width_c'
   sc$aesthetics <- 'edge_width'
   sc
 }
@@ -51,20 +48,19 @@ scale_edge_width_continuous <- function(
 scale_edge_width <- scale_edge_width_continuous
 #' @rdname scale_edge_width
 #'
-#' @inheritParams ggplot2::scale_size_discrete
+#' @inheritParams ggplot2::scale_linewidth_discrete
 #' @export
 scale_edge_width_discrete <- function(...) {
   cli::cli_warn(
     "Using {.field edge_width} for a discrete variable is not advised."
   )
-  sc <- scale_size_ordinal(...)
-  sc$scale_name <- 'width_d'
+  sc <- scale_linewidth_ordinal(...)
   sc$aesthetics <- 'edge_width'
   sc
 }
 #' @rdname scale_edge_width
 #'
-#' @inheritParams ggplot2::scale_size_binned
+#' @inheritParams ggplot2::scale_linewidth_binned
 #' @export
 scale_edge_width_binned <- function(
   name = waiver(),
@@ -77,7 +73,7 @@ scale_edge_width_binned <- function(
   trans = "identity",
   guide = "bins"
 ) {
-  sc <- scale_size_binned(
+  sc <- scale_linewidth_binned(
     name = name,
     breaks = breaks,
     labels = labels,
@@ -88,13 +84,12 @@ scale_edge_width_binned <- function(
     trans = trans,
     guide = guide
   )
-  sc$scale_name <- 'width_b'
   sc$aesthetics <- 'edge_width'
   sc
 }
 #' @rdname scale_edge_width
 #'
-#' @inheritParams ggplot2::scale_size_manual
+#' @inheritParams ggplot2::scale_linewidth_manual
 #'
 #' @export
 scale_edge_width_manual <- function(
@@ -103,7 +98,7 @@ scale_edge_width_manual <- function(
   breaks = waiver(),
   na.value = NA
 ) {
-  sc <- scale_size_manual(
+  sc <- scale_linewidth_manual(
     ...,
     values = values,
     breaks = breaks,
@@ -114,11 +109,11 @@ scale_edge_width_manual <- function(
 }
 #' @rdname scale_edge_width
 #'
-#' @inheritParams ggplot2::scale_size_identity
+#' @inheritParams ggplot2::scale_linewidth_identity
 #'
 #' @export
 scale_edge_width_identity <- function(..., guide = 'none') {
-  sc <- scale_size_identity(..., guide = guide)
+  sc <- scale_linewidth_identity(..., guide = guide)
   sc$aesthetics <- 'edge_width'
   sc
 }

--- a/man/geom_node_arc_bar.Rd
+++ b/man/geom_node_arc_bar.Rd
@@ -87,7 +87,7 @@ as created with circular partition layouts
 }
 \section{Aesthetics}{
 
-\code{geom_node_point} understand the following aesthetics. Bold aesthetics are
+\code{geom_node_arc_bar} understand the following aesthetics. Bold aesthetics are
 automatically set, but can be overwritten.
 \itemize{
 \item \strong{x0}
@@ -99,9 +99,8 @@ automatically set, but can be overwritten.
 \item alpha
 \item colour
 \item fill
-\item shape
-\item size
-\item stroke
+\item linewidth
+\item linetype
 \item filter
 }
 }

--- a/man/geom_node_circle.Rd
+++ b/man/geom_node_circle.Rd
@@ -97,9 +97,8 @@ automatically set, but can be overwritten.
 \item alpha
 \item colour
 \item fill
-\item shape
-\item size
-\item stroke
+\item linewidth
+\item linetype
 \item filter
 }
 }

--- a/man/geom_node_range.Rd
+++ b/man/geom_node_range.Rd
@@ -87,7 +87,7 @@ layout for showing the horizontal span of each node.
 }
 \section{Aesthetics}{
 
-\code{geom_node_point} understand the following aesthetics. Bold aesthetics are
+\code{geom_node_range} understand the following aesthetics. Bold aesthetics are
 automatically set, but can be overwritten.
 \itemize{
 \item \strong{x}
@@ -97,7 +97,7 @@ automatically set, but can be overwritten.
 \item alpha
 \item colour
 \item linetype
-\item size
+\item linewidth
 \item filter
 }
 }

--- a/man/geom_node_tile.Rd
+++ b/man/geom_node_tile.Rd
@@ -84,13 +84,11 @@ lists which parameters it can accept.
 \description{
 A treemap is a space filling layout that recursively divides a rectangle to
 the children of the node. Often only the leaf nodes are drawn as nodes higher
-up in the hierarchy would obscure what is below. \code{geom_treemap} is a
-shorthand for \code{geom_node_treemap} as node is implicit in the case of
-treemap drawing
+up in the hierarchy would obscure what is below.
 }
 \section{Aesthetics}{
 
-\code{geom_treemap} understand the following aesthetics. Bold aesthetics are
+\code{geom_node_tile} understand the following aesthetics. Bold aesthetics are
 automatically set, but can be overwritten.
 \itemize{
 \item \strong{x}
@@ -100,8 +98,8 @@ automatically set, but can be overwritten.
 \item alpha
 \item colour
 \item fill
-\item size
-\item stroke
+\item linewidth
+\item linetype
 \item filter
 }
 }

--- a/man/geom_node_voronoi.Rd
+++ b/man/geom_node_voronoi.Rd
@@ -136,9 +136,8 @@ automatically set, but can be overwritten.
 \item alpha
 \item colour
 \item fill
-\item shape
-\item size
-\item stroke
+\item linewidth
+\item linetype
 \item filter
 }
 }

--- a/man/scale_edge_width.Rd
+++ b/man/scale_edge_width.Rd
@@ -102,8 +102,28 @@ maximum size of the plotting symbol after transformation.}
 \code{\link[ggplot2:guides]{guides()}} for more information.}
 
 \item{...}{
-  Arguments passed on to \code{\link[ggplot2:continuous_scale]{continuous_scale}}
+  Arguments passed on to \code{\link[ggplot2:discrete_scale]{discrete_scale}}
   \describe{
+    \item{\code{limits}}{One of:
+\itemize{
+\item \code{NULL} to use the default scale values
+\item A character vector that defines possible values of the scale and their
+order
+\item A function that accepts the existing (automatic) values and returns
+new ones. Also accepts rlang \link[rlang:as_function]{lambda} function
+notation.
+}}
+    \item{\code{drop}}{Should unused factor levels be omitted from the scale?
+The default, \code{TRUE}, uses the levels that appear in the data;
+\code{FALSE} includes the levels in the factor. Please note that to display
+every level in a legend, the layer should use \code{show.legend = TRUE}.}
+    \item{\code{na.translate}}{Unlike continuous scales, discrete scales can easily show
+missing values, and do so by default. If you want to remove missing values
+from a discrete scale, specify \code{na.translate = FALSE}.}
+    \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
     \item{\code{minor_breaks}}{One of:
 \itemize{
 \item \code{NULL} for no minor breaks
@@ -115,17 +135,21 @@ accepts rlang \link[rlang:as_function]{lambda} function notation. When
 the function has two arguments, it will be given the limits and major
 break positions.
 }}
-    \item{\code{oob}}{One of:
+    \item{\code{labels}}{One of the options below. Please note that when \code{labels} is a
+vector, it is highly recommended to also set the \code{breaks} argument as a
+vector to protect against unintended mismatches.
 \itemize{
-\item Function that handles limits outside of the scale limits
-(out of bounds). Also accepts rlang \link[rlang:as_function]{lambda}
-function notation.
-\item The default (\code{\link[scales:oob]{scales::censor()}}) replaces out of
-bounds values with \code{NA}.
-\item \code{\link[scales:oob]{scales::squish()}} for squishing out of bounds values into range.
-\item \code{\link[scales:oob]{scales::squish_infinite()}} for squishing infinite values into range.
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item An expression vector (must be the same length as breaks). See ?plotmath for details.
+\item A function that takes the breaks as input and returns labels
+as output. Also accepts rlang \link[rlang:as_function]{lambda} function
+notation.
 }}
-    \item{\code{na.value}}{Missing values will be replaced with this value.}
+    \item{\code{guide}}{A function used to create a guide or its name. See
+\code{\link[ggplot2:guides]{guides()}} for more information.}
     \item{\code{call}}{The \code{call} used to construct the scale for reporting messages.}
     \item{\code{super}}{The super class to use for the constructed scale}
   }}
@@ -153,13 +177,11 @@ match will be given \code{na.value}.}
 A ggproto object inheriting from \code{Scale}
 }
 \description{
-This set of scales defines width scales for edge geoms. Of all the new edge
-scales defined in ggraph, this is the only one not having an equivalent in
-ggplot2. In essence it mimics the use of size in
-\code{\link[ggplot2:geom_path]{ggplot2::geom_line()}} and related. As almost all edge
-representations are lines of some sort, edge_width will be used much more
-often than edge_size. It is not necessary to spell out that it is an edge
-scale as the geom knows if it is drawing an edge. Just write \code{width} and
+This set of scales defines width scales for edge geoms. In essence it mimics
+the use of \code{linewidth} in \code{\link[ggplot2:geom_path]{ggplot2::geom_line()}} and related. As almost all
+edge representations are lines of some sort, \code{edge_width} will be used much
+more often than \code{edge_size}. It is not necessary to spell out that it is an
+edge scale as the geom knows if it is drawing an edge. Just write \code{width} and
 not \code{edge_width} in the call to geoms.
 }
 \seealso{


### PR DESCRIPTION
This PR aims to fix an issue discussed off-github.

The issue was several node geoms still using the `size` aesthetic instead of `linewidth`.
I didn't find this to be the case, but the documentation sometimes deviated from what aesthetics are available.
The documentation would fix #374.
