### PR TITLE
Use absolute size for `guide_edge_direction()`  arrow line

### DIFF
--- a/R/edge_direction.R
+++ b/R/edge_direction.R
@@ -224,10 +224,11 @@ GuideEdgeDirection <- ggproto(
 
   build_labels = function(key, elements, params) {
     if (params$arrow) {
+      size <- switch(params$direction, horizontal = elements$width_cm, elements$height_cm)
       list(
         labels = flip_element_grob(
           elements$arrow_line,
-          x = unit(c(0, 1), "npc"),
+          x = unit(c(0, size), "cm"),
           y = unit(c(0.5, 0.5), "npc"),
           flip = params$direction == "vertical"
         )


### PR DESCRIPTION
This PR aims to fix #385.

It set the size of the arrow to the absolute size.

``` r
devtools::load_all("~/packages/test/ggraph/")
#> ℹ Loading ggraph
#> Loading required package: ggplot2

gr <- tidygraph::as_tbl_graph(highschool)
ggraph(gr, layout = 'kk') +
  geom_edge_fan(aes(alpha = after_stat(index))) +
  guides(edge_alpha = guide_edge_direction())
```

![](https://i.imgur.com/C1fMNnJ.png)<!-- -->

<sup>Created on 2025-10-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Compared to the current pkgdown image:

![](https://ggraph.data-imaginist.com/reference/guide_edge_direction-1.png)
